### PR TITLE
bugfix patch backport: "hrtimer: Preserve timer state in remove_hrtimer()"

### DIFF
--- a/kernel/hrtimer.c
+++ b/kernel/hrtimer.c
@@ -936,6 +936,7 @@ static inline int
 remove_hrtimer(struct hrtimer *timer, struct hrtimer_clock_base *base)
 {
 	if (hrtimer_is_queued(timer)) {
+		unsigned long state;
 		int reprogram;
 
 		/*
@@ -949,8 +950,13 @@ remove_hrtimer(struct hrtimer *timer, struct hrtimer_clock_base *base)
 		debug_deactivate(timer);
 		timer_stats_hrtimer_clear_start_info(timer);
 		reprogram = base->cpu_base == &__get_cpu_var(hrtimer_bases);
-		__remove_hrtimer(timer, base, HRTIMER_STATE_INACTIVE,
-				 reprogram);
+		/*
+		 * We must preserve the CALLBACK state flag here,
+		 * otherwise we could move the timer base in
+		 * switch_hrtimer_base.
+		 */
+		state = timer->state & HRTIMER_STATE_CALLBACK;
+		__remove_hrtimer(timer, base, state, reprogram);
 		return 1;
 	}
 	return 0;
@@ -1237,6 +1243,9 @@ static void __run_hrtimer(struct hrtimer *timer, ktime_t *now)
 		BUG_ON(timer->state != HRTIMER_STATE_CALLBACK);
 		enqueue_hrtimer(timer, base);
 	}
+
+	WARN_ON_ONCE(!(timer->state & HRTIMER_STATE_CALLBACK));
+
 	timer->state &= ~HRTIMER_STATE_CALLBACK;
 }
 


### PR DESCRIPTION
This patch is to fix a kernel panic in tc-htb qdisc, but the root cause is a race condition
in hrtimer remove logic, below are information of original commit:

commit f13d4f979c518119bba5439dd2364d76d31dcd3f
Author: Salman Qazi <sqazi@google.com>
Date:   Tue Oct 12 07:25:19 2010 -0700

    hrtimer: Preserve timer state in remove_hrtimer()

    The race is described as follows:

    CPU X                                 CPU Y
    remove_hrtimer
    // state & QUEUED == 0
    timer->state = CALLBACK
    unlock timer base
    timer->f(n) //very long
                                      hrtimer_start
                                        lock timer base
                                        remove_hrtimer // no effect
                                        hrtimer_enqueue
                                        timer->state = CALLBACK |
                                                       QUEUED
                                        unlock timer base
                                      hrtimer_start
                                        lock timer base
                                        remove_hrtimer
                                            mode = INACTIVE
                                            // CALLBACK bit lost!
                                        switch_hrtimer_base
                                                CALLBACK bit not set:
                                                        timer->base
                                                        changes to a
                                                        different CPU.
    lock this CPU's timer base

    The bug was introduced with commit ca109491f (hrtimer: removing all
ur
    callback modes) in 2.6.29
    [ tglx: Feed new state via local variable and add a comment. ]

    Signed-off-by: Salman Qazi <sqazi@google.com>
    Cc: akpm@linux-foundation.org
    Cc: Peter Zijlstra <peterz@infradead.org>
    LKML-Reference:
<20101012142351.8485.21823.stgit@dungbeetle.mtv.corp.google.com>
    Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
    Cc: stable@kernel.org