### PR TITLE
backport bug fix : Fixed a bug in handling IOMMU address limits

### DIFF
--- a/drivers/pci/intel-iommu.c
+++ b/drivers/pci/intel-iommu.c
@@ -735,7 +735,11 @@ static struct dma_pte *pfn_to_dma_pte(struct dmar_domain *domain,
 	int offset;
 
 	BUG_ON(!domain->pgd);
-	BUG_ON(addr_width < BITS_PER_LONG && pfn >> addr_width);
+
+	if (addr_width < BITS_PER_LONG && pfn >> addr_width)
+		/* Address beyond IOMMU's addressing capabilities. */
+		return NULL;
+
 	parent = domain->pgd;
 
 	while (level > 0) {


### PR DESCRIPTION
A abnormal GFN may break down host kernel, this patch is to fix it.
Thank Tian Yi of virtualization team for report this bug.

commit f9423606ade08653dd8a43334f0a7fb45504c5cc
Author: Julian Stecklina <jsteckli@os.inf.tu-dresden.de>
Date:   Wed Oct 9 10:03:52 2013 +0200

    iommu/vt-d: Fixed interaction of VFIO_IOMMU_MAP_DMA with IOMMU address limits

    The BUG_ON in drivers/iommu/intel-iommu.c:785 can be triggered from userspace via
    VFIO by calling the VFIO_IOMMU_MAP_DMA ioctl on a vfio device with any address
    beyond the addressing capabilities of the IOMMU. The problem is that the ioctl code
    calls iommu_iova_to_phys before it calls iommu_map. iommu_map handles the case that
    it gets addresses beyond the addressing capabilities of its IOMMU.
    intel_iommu_iova_to_phys does not.

    This patch fixes iommu_iova_to_phys to return NULL for addresses beyond what the
    IOMMU can handle. This in turn causes the ioctl call to fail in iommu_map and
    (correctly) return EFAULT to the user with a helpful warning message in the kernel
    log.

    Signed-off-by: Julian Stecklina <jsteckli@os.inf.tu-dresden.de>
    Acked-by: Alex Williamson <alex.williamson@redhat.com>
    Signed-off-by: Joerg Roedel <joro@8bytes.org>