### PR TITLE
Refactoring conditional directives that break parts of statements.

### DIFF
--- a/lib/inflate.c
+++ b/lib/inflate.c
@@ -841,6 +841,7 @@ STATIC int noinline INIT inflate_dynamic(void)
   register ulg b;       /* bit buffer */
   register unsigned k;  /* number of bits in bit buffer */
   int ret;
+  int n_test;
 
 DEBG("<dyn");
 
@@ -869,10 +870,11 @@ DEBG("<dyn");
   nb = 4 + ((unsigned)b & 0xf);         /* number of bit length codes */
   DUMPBITS(4)
 #ifdef PKZIP_BUG_WORKAROUND
-  if (nl > 288 || nd > 32)
+  n_test = (nl > 288 || nd > 32);
 #else
-  if (nl > 286 || nd > 30)
+  n_test = (nl > 286 || nd > 30);
 #endif
+  if (n_test)
   {
     ret = 1;             /* bad lengths */
     goto out;


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.